### PR TITLE
Fix: remove donation_type from donation_meta table

### DIFF
--- a/db/migrate/20160409211738_remove_type_id_from_donation_metum.rb
+++ b/db/migrate/20160409211738_remove_type_id_from_donation_metum.rb
@@ -1,0 +1,5 @@
+class RemoveTypeIdFromDonationMetum < ActiveRecord::Migration
+  def change
+    remove_column :donation_meta, :donation_type
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160409211227) do
+ActiveRecord::Schema.define(version: 20160409211738) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -50,10 +50,9 @@ ActiveRecord::Schema.define(version: 20160409211227) do
   add_index "admin_users", ["reset_password_token"], name: "index_admin_users_on_reset_password_token", unique: true, using: :btree
 
   create_table "donation_meta", force: :cascade do |t|
-    t.datetime "created_at",    null: false
-    t.datetime "updated_at",    null: false
+    t.datetime "created_at",  null: false
+    t.datetime "updated_at",  null: false
     t.integer  "donation_id"
-    t.string   "donation_type"
   end
 
   create_table "donation_statuses", force: :cascade do |t|


### PR DESCRIPTION
This is a fix to remove the donation type from the donation_meta table.  At some point, we will need to add a few fields to the donation meta table, but for now we can move forward with the current Schema.
