### PR TITLE
Feat rc add donation status endpoint

### DIFF
--- a/app/controllers/api/v1/donations_controller.rb
+++ b/app/controllers/api/v1/donations_controller.rb
@@ -22,6 +22,20 @@ class Api::V1::DonationsController < ApplicationController
     end
   end
 
+  def status
+    donation = current_user.donations.find(params[:donation_id])
+    status_hash = donation[:status]
+    if status_hash[:status_id]
+      donation.status = DonationStatus.find(status_hash[:donation_status_id])
+    end
+    if status_hash[:pickup_status_id]
+      donation.pickup.status = Pickupstatus.find(status_hash[:pickup_status_id])
+    end
+    if status_hash[:dropoff_status_id]
+      donation.dropoff.status = Dropoffstatus.find(status_hash[:dropoff_status_id])
+    end
+  end
+
   def update
     donation = current_user.donations.find(params[:id])
     if donation.update(donation_params)
@@ -45,6 +59,12 @@ class Api::V1::DonationsController < ApplicationController
       params.require(:donation).permit(:id, :description, :status_id)
     end
 
+    def status_params
+      params.require(:status).permit(:donation_status_id,
+                                     :dropoff_status_id,
+                                     :pickup_status_id)
+    end
+
     # TODO: add a better mechanism for how the recipient is created.
     def recipient_params
       params.require(:recipient).permit(:id, :name,
@@ -52,5 +72,10 @@ class Api::V1::DonationsController < ApplicationController
                                         :latitude, :longitude,
                                         :street_address, :street_address_two,
                                         :donation_id, :city, :state, :zip)
+    end
+    def status_params
+      params.require(:donation).permit(:donation_status,
+                                       :pickup_status,
+                                       :dropoff_status)
     end
 end

--- a/app/controllers/api/v1/driver/driver_controller.rb
+++ b/app/controllers/api/v1/driver/driver_controller.rb
@@ -1,3 +1,5 @@
 class Api::V1::DriverController < ApplicationController
   skip_before_action :verify_authenticity_token
+  def index
+  end
 end

--- a/app/controllers/api/v1/driver/driver_donations_controller.rb
+++ b/app/controllers/api/v1/driver/driver_donations_controller.rb
@@ -23,12 +23,18 @@ class Api::V1::Driver::DriverDonationsController < ApplicationController
 
   def accepted
     donations = Donation.where(status_id: 1)
+    respond_with donations
   end
 
   def completed
-
+    donations = Donation.where(status_id: 2)
   end
+
   def donation_params
     params.require(:donation).permit(:id, :description, :status_id)
+  end
+
+  def status_params
+    params.require(:donation).permit(:status_id, :pickup_status_id, :dropoff_status_id)
   end
 end

--- a/app/models/donation.rb
+++ b/app/models/donation.rb
@@ -56,6 +56,10 @@ class Donation < ActiveRecord::Base
       self.dropoff.status = Dropoffstatus.first
     end
 
+    def create_recipient
+
+    end
+
     def set_recipient
 
     end

--- a/app/models/donation.rb
+++ b/app/models/donation.rb
@@ -1,6 +1,6 @@
 class Donation < ActiveRecord::Base
 
-  after_initialize :set_default_values
+  before_validation :set_default_values
 
   belongs_to :donor, :class_name => "Donor", :foreign_key => "donor_id"
   belongs_to :driver, :class_name => "Driver", :foreign_key => "driver_id"
@@ -21,6 +21,10 @@ class Donation < ActiveRecord::Base
     Donation.where(status: 0).order(updated_at: :desc)
   end
 
+  def status_name
+    self.status.name ? self.status.name : nil
+  end
+
   def donation_types_array
     array = []
     donation_types.each do |type|
@@ -33,8 +37,26 @@ class Donation < ActiveRecord::Base
 
     # Set the default status when a donation is created.
     def set_default_values
+      set_default_status
+      create_pickup
+      create_dropoff
+    end
+
+    def set_default_status
       self.status ||= DonationStatus.find(0)
     end
 
+    def create_pickup
+      self.pickup = Pickup.create
+      self.pickup.status = Pickupstatus.first
+    end
 
+    def create_dropoff
+      self.dropoff = Dropoff.create
+      self.dropoff.status = Dropoffstatus.first
+    end
+
+    def set_recipient
+
+    end
 end

--- a/app/models/donation.rb
+++ b/app/models/donation.rb
@@ -40,6 +40,7 @@ class Donation < ActiveRecord::Base
       set_default_status
       create_pickup
       create_dropoff
+      create_donation_metum
     end
 
     def set_default_status
@@ -60,7 +61,7 @@ class Donation < ActiveRecord::Base
 
     end
 
-    def set_recipient
-
+    def create_donation_metum
+      self.donation_metum = DonationMetum.create
     end
 end

--- a/app/models/driver.rb
+++ b/app/models/driver.rb
@@ -5,6 +5,15 @@ class Driver < User
   has_many :pickups, through: :donations
   has_many :dropoffs, through: :donations
 
+  def active
+    self.setting.active
+  end
+
+  def active=(status)
+    self.setting.active = status
+    self.save
+  end
+
   private
     def set_default_role!
       begin

--- a/app/models/driver.rb
+++ b/app/models/driver.rb
@@ -10,7 +10,7 @@ class Driver < User
       begin
         @role = Role.find_by_description self.type
       rescue
-        raise "Error setting default role for donor."
+        raise "Error setting default role for driver."
       end
     end
 end

--- a/app/models/dropoff.rb
+++ b/app/models/dropoff.rb
@@ -2,6 +2,10 @@ class Dropoff < ActiveRecord::Base
   has_one :driver, class_name: "User", through: :donation
   belongs_to :dropoffstatus
 
+  geocoded_by :address
+
+  after_validation :geocode, :if => :address_changed?
+
   def status
    dropoffstatus
   end
@@ -9,6 +13,16 @@ class Dropoff < ActiveRecord::Base
   # Create an alias for status name
   def status_name
     self.status ? self.status.name : nil
+  end
+
+  def address_changed?
+    self.street_address_changed? || self.street_address_two_changed? || self.city_changed? || self.zip_changed?
+  end
+
+  def address
+    addr_array = [self.street_address, self.street_address_two, self.city, self.state, self.zip]
+    address = addr_array.join(', ')
+    address
   end
 
   def status=(status)

--- a/app/models/dropoff.rb
+++ b/app/models/dropoff.rb
@@ -1,15 +1,17 @@
 class Dropoff < ActiveRecord::Base
   has_one :driver, class_name: "User", through: :donation
   belongs_to :dropoffstatus
-  # def status
-  #  status_name = Pickupstatus.find(pickupstatus_id).name
-  #  if status_name
-  #    status_name
-  #  else
-  #    nil
-  #  end
-  # end
-  # def status=(status)
-  #  self.dropoffstatus = status
-  # end
+
+  def status
+   dropoffstatus
+  end
+
+  # Create an alias for status name
+  def status_name
+    self.status ? self.status.name : nil
+  end
+
+  def status=(status)
+    self.dropoffstatus = status
+  end
 end

--- a/app/models/pickup.rb
+++ b/app/models/pickup.rb
@@ -2,15 +2,16 @@ class Pickup < ActiveRecord::Base
   has_one :driver, class_name: "User", :through => :donation
   belongs_to :pickupstatus
 
- # def status
- #   status_name = Pickupstatus.find(pickupstatus_id).name
- #   if status_name
- #     status_name
- #   else
- #     nil
- #   end
- # end
- #  def status=(status)
- #   self.pickupstatus = status
- #  end
+  def status
+   pickupstatus
+  end
+
+  # Create an alias for status name
+  def status_name
+    self.status ? self.status.name : nil
+  end
+
+  def status=(status)
+    self.pickupstatus = status
+  end
 end

--- a/app/models/pickup.rb
+++ b/app/models/pickup.rb
@@ -2,8 +2,24 @@ class Pickup < ActiveRecord::Base
   has_one :driver, class_name: "User", :through => :donation
   belongs_to :pickupstatus
 
+  geocoded_by :address
+
+  after_validation :geocode, :if => :address_changed?
+
   def status
    pickupstatus
+  end
+
+  def address=(opt={})
+    self.street_address = opts[:street_address] if opts[:street_address]
+    self.street_address_two = opts[:street_address_two] if opts[:street_address_two]
+    self.city = opts[:city] if opts[:city]
+    self.state = opts[:state] if opts[:state]
+    self.zip = opts[:zip] if opts[:zip]
+  end
+
+  def address_changed?
+    self.street_address_changed? || self.street_address_two_changed? || self.city_changed? || self.zip_changed?
   end
 
   # Create an alias for status name
@@ -14,4 +30,9 @@ class Pickup < ActiveRecord::Base
   def status=(status)
     self.pickupstatus = status
   end
+
+  def address
+    "#{self.street_address} #{self.street_address_two} #{self.city} #{self.state} #{self.zip}"
+  end
+
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -37,8 +37,8 @@ class User < ActiveRecord::Base
         # Also, need to set the "Type"
       self.role = Role.find(2)
     end
+    set_role_for_type
     set_default_settings
-    set_type_for_role
   end
 
   def set_default_settings
@@ -51,19 +51,22 @@ class User < ActiveRecord::Base
     end
   end
 
+  def settings
+    self.setting
+  end
+
   def update_settings(settings = {})
     if self.setting
       self.setting.update(settings)
     end
   end
 
-  def set_type_for_role
-    # Set the default type if the role is donor or driver
-    if self.role && self.role.id < 2
-      self.type = self.role.description
+  def set_role_for_type
+    role = Role.where(description: self.type).first
+    if role
+      self.role = role
     else
-      # Set the default type as unassigned and then call
-      # set_type_for_role
+      # Set unnassigned if the type is not found
       self.role = Role.last
     end
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -20,6 +20,7 @@ Rails.application.routes.draw do
       end
       namespace :driver do
         get 'donations' => 'driver_donations#index', as: :donations
+        post 'donations/:donation_id/status' => 'donations#status'
       end
       resources :donations, :only => [:show, :index, :update]
       get 'donationspending' => 'donationspending#index'


### PR DESCRIPTION
This will add geocoding for pickup and dropoff locations.  The database will automatically geocode an address passed into the pickup / dropoff.  Note, Reverse geocoding is not yet setup, but can be added.
### Models
#### User / Donor / Driver model

The default role will be set based on the user's type.
#### Donation

Default values are set, creating a pickup, dropoff, a status, and meta table.  A recipient will be added at a later time.
