### PR TITLE
Fix: merge together the pending and donation array in /all

### DIFF
--- a/app/controllers/api/v1/driver/driver_donations_controller.rb
+++ b/app/controllers/api/v1/driver/driver_donations_controller.rb
@@ -5,9 +5,9 @@ class Api::V1::Driver::DriverDonationsController < ApplicationController
   def index
     @pending_donations = Donation.where(status_id: 0)
     @user_donations = current_user.donations.all
+    @all_donations = @pending_donations + @user_donations
     render json: {
-        donations: [ActiveModel::ArraySerializer.new(@pending_donations, each_serializer: DonationSerializer, root: false),
-                    ActiveModel::ArraySerializer.new(@user_donations, each_serializer: DonationSerializer, root: false)]
+        donations: ActiveModel::ArraySerializer.new(@all_donations, each_serializer: DonationSerializer, root: false)
       }
   end
 

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -7,7 +7,7 @@ Role.create!(id: 1, description: 'Driver')
 Role.create!(id: 2, description: 'Other')
 Role.create!(id: 3, description: 'Unassigned')
 
-# Define donatan status
+# Define donation status
 DonationStatus.create!(name: 'Pending', id: 0)
 DonationStatus.create!(name: 'Accepted', id: 1)
 DonationStatus.create!(name: 'Completed', id: 2)


### PR DESCRIPTION
The /driver/donations/all endpoint was returning a nested array, which almost gave @gristoi a stroke.  This hot fix will merge together the arrays before returning, thus ensuring that @gristoi will be able to go on without the need for blood pressure medication. 👍 
