### PR TITLE
Feat rc add donor addresses

### DIFF
--- a/app/models/donor.rb
+++ b/app/models/donor.rb
@@ -3,6 +3,8 @@ class Donor < User
 
   has_many :donations, foreign_key: "donor_id", class_name: "Donation"
 
+  has_many :addresses, foreign_key: "donor_id", class_name: "DonorAddress"
+
   private
     # Set the default role to be equal to the type
     def set_default_role!

--- a/app/models/donor_address.rb
+++ b/app/models/donor_address.rb
@@ -1,0 +1,3 @@
+class DonorAddress < ActiveRecord::Base
+  belongs_to :donor
+end

--- a/app/models/donor_address.rb
+++ b/app/models/donor_address.rb
@@ -1,3 +1,13 @@
 class DonorAddress < ActiveRecord::Base
+  after_initialize :set_default_status
   belongs_to :donor
+
+  # Set the address to be default if it is the only one.
+  def set_default_status
+    count = DonorAddress.where(donor_id: self.donor_id).count
+    if count == nil || count <= 1
+      puts("Count is less than or equal to 1")
+      self.default = true
+    end
+  end
 end

--- a/app/serializers/donor_serializer.rb
+++ b/app/serializers/donor_serializer.rb
@@ -1,3 +1,4 @@
 class DonorSerializer < ActiveModel::Serializer
   attributes :id, :phone, :name, :email, :avatar, :created_at, :updated_at
+  has_many :addresses
 end

--- a/db/migrate/20160506193319_create_donor_addresses.rb
+++ b/db/migrate/20160506193319_create_donor_addresses.rb
@@ -1,0 +1,13 @@
+class CreateDonorAddresses < ActiveRecord::Migration
+  def change
+    create_table :donor_addresses do |t|
+      t.string :street_address
+      t.string :street_address_two
+      t.string :city
+      t.string :state
+      t.string :zip
+
+      t.timestamps null: false
+    end
+  end
+end

--- a/db/migrate/20160506194012_add_donor_id_to_donor_addresses.rb
+++ b/db/migrate/20160506194012_add_donor_id_to_donor_addresses.rb
@@ -1,0 +1,5 @@
+class AddDonorIdToDonorAddresses < ActiveRecord::Migration
+  def change
+    add_reference :donor_addresses, :donor, index: true
+  end
+end

--- a/db/migrate/20160506194506_add_default_to_donor_address.rb
+++ b/db/migrate/20160506194506_add_default_to_donor_address.rb
@@ -1,0 +1,5 @@
+class AddDefaultToDonorAddress < ActiveRecord::Migration
+  def change
+    add_column :donor_addresses, :default, :boolean, :default => false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160506194012) do
+ActiveRecord::Schema.define(version: 20160506194506) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -92,9 +92,10 @@ ActiveRecord::Schema.define(version: 20160506194012) do
     t.string   "city"
     t.string   "state"
     t.string   "zip"
-    t.datetime "created_at",         null: false
-    t.datetime "updated_at",         null: false
+    t.datetime "created_at",                         null: false
+    t.datetime "updated_at",                         null: false
     t.integer  "donor_id"
+    t.boolean  "default",            default: false
   end
 
   add_index "donor_addresses", ["donor_id"], name: "index_donor_addresses_on_donor_id", using: :btree

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160428175144) do
+ActiveRecord::Schema.define(version: 20160506194012) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -72,6 +72,8 @@ ActiveRecord::Schema.define(version: 20160428175144) do
     t.string   "description"
     t.datetime "created_at",  null: false
     t.datetime "updated_at",  null: false
+    t.integer  "quantity"
+    t.string   "unit"
   end
 
   create_table "donations", force: :cascade do |t|
@@ -83,6 +85,19 @@ ActiveRecord::Schema.define(version: 20160428175144) do
     t.integer  "status_id"
     t.string   "description"
   end
+
+  create_table "donor_addresses", force: :cascade do |t|
+    t.string   "street_address"
+    t.string   "street_address_two"
+    t.string   "city"
+    t.string   "state"
+    t.string   "zip"
+    t.datetime "created_at",         null: false
+    t.datetime "updated_at",         null: false
+    t.integer  "donor_id"
+  end
+
+  add_index "donor_addresses", ["donor_id"], name: "index_donor_addresses_on_donor_id", using: :btree
 
   create_table "dropoffs", force: :cascade do |t|
     t.datetime "estimated"

--- a/db/seeds/development.rb
+++ b/db/seeds/development.rb
@@ -90,6 +90,35 @@ users.each do |u|
 end
 
 
+donors = Donor.all
+
+# Create addresses for the donor
+donors.each do |donor|
+  donor.addresses << DonorAddress.create(donor_id: donor.id,
+                                         street_address: FFaker::AddressUS.street_address,
+                                         street_address_two: FFaker::AddressUS.secondary_address,
+                                         city: FFaker::AddressUS.city,
+                                         state: FFaker::AddressUS.state,
+                                         zip: FFaker::AddressUS.zip_code.split('-')[0].to_s,
+                                         default: true)
+
+ donor.addresses << DonorAddress.create(donor_id: donor.id,
+                                        street_address: FFaker::AddressUS.street_address,
+                                        street_address_two: FFaker::AddressUS.secondary_address,
+                                        city: FFaker::AddressUS.city,
+                                        state: FFaker::AddressUS.state,
+                                        zip: FFaker::AddressUS.zip_code.split('-')[0].to_s,
+                                        default: false)
+
+donor.addresses << DonorAddress.create(donor_id: donor.id,
+                                       street_address: FFaker::AddressUS.street_address,
+                                       street_address_two: FFaker::AddressUS.secondary_address,
+                                       city: FFaker::AddressUS.city,
+                                       state: FFaker::AddressUS.state,
+                                       zip: FFaker::AddressUS.zip_code.split('-')[0].to_s,
+                                       default: false)
+end
+
 # Dummy recipients
 100.times do |n|
   Recipient.create!(name: FFaker::Company.name,

--- a/db/seeds/production.rb
+++ b/db/seeds/production.rb
@@ -90,6 +90,35 @@ users.each do |u|
 end
 
 
+donors = Donor.all
+
+# Create addresses for the donor
+donors.each do |donor|
+  donor.addresses << DonorAddress.create(donor_id: donor.id,
+                                         street_address: FFaker::AddressUS.street_address,
+                                         street_address_two: FFaker::AddressUS.secondary_address,
+                                         city: FFaker::AddressUS.city,
+                                         state: FFaker::AddressUS.state,
+                                         zip: FFaker::AddressUS.zip_code.split('-')[0].to_s,
+                                         default: true)
+
+ donor.addresses << DonorAddress.create(donor_id: donor.id,
+                                        street_address: FFaker::AddressUS.street_address,
+                                        street_address_two: FFaker::AddressUS.secondary_address,
+                                        city: FFaker::AddressUS.city,
+                                        state: FFaker::AddressUS.state,
+                                        zip: FFaker::AddressUS.zip_code.split('-')[0].to_s,
+                                        default: false)
+
+donor.addresses << DonorAddress.create(donor_id: donor.id,
+                                       street_address: FFaker::AddressUS.street_address,
+                                       street_address_two: FFaker::AddressUS.secondary_address,
+                                       city: FFaker::AddressUS.city,
+                                       state: FFaker::AddressUS.state,
+                                       zip: FFaker::AddressUS.zip_code.split('-')[0].to_s,
+                                       default: false)
+end
+
 # Dummy recipients
 100.times do |n|
   Recipient.create!(name: FFaker::Company.name,

--- a/spec/factories/donor_addresses.rb
+++ b/spec/factories/donor_addresses.rb
@@ -1,0 +1,10 @@
+FactoryGirl.define do
+  factory :donor_address do
+    donor nil
+    street_address "MyString"
+    street_address_two "MyString"
+    city "MyString"
+    state "MyString"
+    zip "MyString"
+  end
+end

--- a/spec/models/donor_address_spec.rb
+++ b/spec/models/donor_address_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe DonorAddress, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end


### PR DESCRIPTION
Update the API to include addresses for donor

Each donor can have an array of related DonationAddresses. 
The Seed data is populated with said addresses and serialized in the donor_serializer.
